### PR TITLE
Reduce use of scap term in sdk

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -19,16 +19,16 @@ package sdk
 // Functions that return or update a rc (e.g. plugin_init,
 // plugin_open) should return one of these values.
 const (
-	ScapSuccess         int32 = 0
-	ScapFailure         int32 = 1
-	ScapTimeout         int32 = -1
-	ScapIllegalInput    int32 = 3
-	ScapNotFound        int32 = 4
-	ScapInputTooSmall   int32 = 5
-	ScapEOF             int32 = 6
-	ScapUnexpectedBlock int32 = 7
-	ScapVersionMismatch int32 = 8
-	ScapNotSupported    int32 = 9
+	SSPluginSuccess         int32 = 0
+	SSPluginFailure         int32 = 1
+	SSPluginTimeout         int32 = -1
+	SSPluginIllegalInput    int32 = 3
+	SSPluginNotFound        int32 = 4
+	SSPluginInputTooSmall   int32 = 5
+	SSPluginEOF             int32 = 6
+	SSPluginUnexpectedBlock int32 = 7
+	SSPluginVersionMismatch int32 = 8
+	SSPluginNotSupported    int32 = 9
 )
 
 // One of these values should be returned by plugin_get_type().

--- a/wrappers/wrappers.go
+++ b/wrappers/wrappers.go
@@ -159,7 +159,7 @@ func WrapExtractFuncs(plgState unsafe.Pointer, evt unsafe.Pointer, numFields uin
 		}
 	}
 
-	return sdk.ScapSuccess
+	return sdk.SSPluginSuccess
 }
 
 // RegisterAsyncExtractors is a helper function to be used within plugin_register_async_extractor.
@@ -200,7 +200,7 @@ func RegisterAsyncExtractors(
 	go func() {
 		info := (*C.async_extractor_info)(asyncExtractorInfo)
 		for C.wait_bridge(info) {
-			info.rc = C.int32_t(sdk.ScapSuccess)
+			info.rc = C.int32_t(sdk.SSPluginSuccess)
 
 			dataBuf := C.GoBytes(unsafe.Pointer(info.evt.data), C.int(info.evt.datalen))
 
@@ -220,7 +220,7 @@ func RegisterAsyncExtractors(
 						info.field.res_str = nil
 					}
 				} else {
-					info.rc = C.int32_t(sdk.ScapNotSupported)
+					info.rc = C.int32_t(sdk.SSPluginNotSupported)
 				}
 			case sdk.ParamTypeUint64:
 				if u64ExtractorFunc != nil {
@@ -233,14 +233,14 @@ func RegisterAsyncExtractors(
 						info.field.res_u64 = C.uint64_t(u64)
 					}
 				} else {
-					info.rc = C.int32_t(sdk.ScapNotSupported)
+					info.rc = C.int32_t(sdk.SSPluginNotSupported)
 				}
 			default:
-				info.rc = C.int32_t(sdk.ScapNotSupported)
+				info.rc = C.int32_t(sdk.SSPluginNotSupported)
 			}
 		}
 	}()
-	return sdk.ScapSuccess
+	return sdk.SSPluginSuccess
 }
 
 // NextFunc is the function type required by NextBatch().
@@ -259,7 +259,7 @@ type NextFunc func(plgState unsafe.Pointer, openState unsafe.Pointer) (*sdk.Plug
 //
 //        // Populate ret here
 //
-//        return ret, sdk.ScapSuccess
+//        return ret, sdk.SSPluginSuccess
 //    }
 //
 //    //export plugin_next_batch
@@ -270,18 +270,18 @@ type NextFunc func(plgState unsafe.Pointer, openState unsafe.Pointer) (*sdk.Plug
 //        return res
 //    }
 func NextBatch(plgState unsafe.Pointer, openState unsafe.Pointer, nextf NextFunc) ([]*sdk.PluginEvent, int32) {
-	res := sdk.ScapSuccess
+	res := sdk.SSPluginSuccess
 
 	evts := make([]*sdk.PluginEvent, 0)
 
 	for len(evts) < sdk.MaxNextBatchEvents {
 		var evt *sdk.PluginEvent
 		evt, res = nextf(plgState, openState)
-		if res == sdk.ScapSuccess {
+		if res == sdk.SSPluginSuccess {
 			evts = append(evts, evt)
-		} else if res == sdk.ScapEOF {
+		} else if res == sdk.SSPluginEOF {
 			// Return success but stop
-			res = sdk.ScapSuccess
+			res = sdk.SSPluginSuccess
 			break
 		} else {
 			break
@@ -299,7 +299,7 @@ func NextBatch(plgState unsafe.Pointer, openState unsafe.Pointer, nextf NextFunc
 //    //export plugin_next_batch
 //    func plugin_next_batch(plgState unsafe.Pointer, openState unsafe.Pointer, nevts *uint32, retEvts **C.ss_plugin_event) int32 {
 //        evts, res := wrappers.NextBatch(plgState, openState, MyNext)
-//        if res == sdk.ScapSuccess {
+//        if res == sdk.SSPluginSuccess {
 //            *retEvts = (*C.ss_plugin_event)(wrappers.Events(evts))
 //            *nevts = (uint32)(len(evts))
 //        }


### PR DESCRIPTION
Prior versions used the term Scap in error codes because that's what
the plugin framework itself uses when opening plugins to source and
interact with events.

However, the term scap/libscap won't make sense to plugin authors. To
avoid this confusion use SSPlugin instead.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>